### PR TITLE
Add repeating schedules

### DIFF
--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -120,7 +120,12 @@ function publish_box_ui() {
 function post_states( $post_states ) {
 
 	if ( is_repeating_post( get_the_id() ) ) {
-		$post_states['hm-post-repeat'] = __( 'Repeating', 'hm-post-repeat' );
+		// If the schedule has been removed since publishing, let the user know.
+		if ( get_repeating_schedule( get_the_id() ) ) {
+			$post_states['hm-post-repeat'] = __( 'Repeating', 'hm-post-repeat' );
+		} else {
+			$post_states['hm-post-repeat'] = __( 'Invalid Repeating Schedule', 'hm-post-repeat' );
+		}
 	}
 
 	if ( is_repeat_post( get_the_id() ) ) {

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -41,7 +41,7 @@ add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 add_filter( 'display_post_states', __NAMESPACE__ . '\post_states' );
 
 /**
- * Enqueue the scripts and styles that are needed by this plugin
+ * Enqueue the scripts and styles that are needed by this plugin.
  */
 function enqueue_scripts( $hook ) {
 
@@ -111,7 +111,7 @@ function publish_box_ui() {
 /**
  * Add some custom post states to cover repeat and repeating posts.
  *
- * By default post states are displayed on the Edit Post screen in bold after the post title
+ * By default post states are displayed on the Edit Post screen in bold after the post title.
  *
  * @param array $post_states The original array of post states.
  * @return array The array of post states with ours added.
@@ -146,7 +146,7 @@ function post_states( $post_states ) {
  * to publish in the chosen interval. That way the next repeat post is always ready to go.
  * This is hooked into save_post to make sure that all post fields and meta are up to date.
  *
- * @param integer $post_id The ID of the post.
+ * @param int     $post_id The ID of the post.
  * @param WP_Post $post    The WP_Post object of the post.
  */
 function create_next_post( $post_id, $post ) {
@@ -328,7 +328,7 @@ function get_repeating_schedule( $post_id ) {
 /**
  * Fix the repeating schedule of the given post_id.
  *
- * This is to check existing repeating posts and correctly set the repeatable post meta.
+ * This is to check existing repeating posts and correctly set the repeatable post meta field.
  * If the default "1" value is found, update it to the standard "weekly".
  *
  * @param int $post_id The id of the post you want to check.
@@ -347,7 +347,7 @@ function fix_repeating_schedule( $post_id ) {
  * A repeating post is defined as the original post that was set to repeat.
  *
  * @param int $post_id The id of the post you want to check.
- * @return bool Whether the past post_id is a repeating post or not.
+ * @return bool Whether the passed post_id is a repeating post or not.
  */
 function is_repeating_post( $post_id ) {
 
@@ -367,10 +367,10 @@ function is_repeating_post( $post_id ) {
 /**
  * Check whether a given post_id is a repeat post.
  *
- * A repeat post is defined as any post which is a repeat of the original repeating post
+ * A repeat post is defined as any post which is a repeat of the original repeating post.
  *
  * @param int $post_id The id of the post you want to check.
- * @return bool Whether the past post_id is a repeat post or not.
+ * @return bool Whether the passed post_id is a repeat post or not.
  */
 function is_repeat_post( $post_id ) {
 

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -303,7 +303,7 @@ function repeating_schedules() {
 function get_repeating_schedule( $post_id ) {
 
 	if ( ! is_repeating_post( $post_id ) ) {
-		return null;
+		return;
 	}
 
 	if ( $repeating_schedule = get_post_meta( $post_id, 'hm-post-repeat', true ) ) {
@@ -312,8 +312,6 @@ function get_repeating_schedule( $post_id ) {
 			return $schedules[ $repeating_schedule ];
 		}
 	}
-
-	return null;
 
 }
 

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -167,10 +167,13 @@ function create_next_post( $post_id, $post ) {
 	elseif ( is_repeating_post( $post_id ) ) {
 
 		if ( isset( $_POST['hm-post-repeat'] ) ) {
-			if ( 'no' === $_POST['hm-post-repeat'] ) {
+			$post_repeat = sanitize_text_field( $_POST['hm-post-repeat'] );
+
+			// This is where we make sure that only available schedules can be selected
+			if ( ! in_array( $post_repeat, array_keys( repeating_schedules() ) ) ) {
 				delete_post_meta( $post_id, 'hm-post-repeat' );
 			} else {
-				update_post_meta( $post_id, 'hm-post-repeat', $_POST['hm-post-repeat'] );
+				update_post_meta( $post_id, 'hm-post-repeat', $post_repeat );
 			}
 		}
 	}

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -248,6 +248,55 @@ function repeating_post_types() {
 }
 
 /**
+ * All available repeat schedules.
+ *
+ * @return array An array of all available repeat schedules
+ */
+function repeating_schedules() {
+
+	/**
+	 * Enable support for additional schedules.
+	 *
+	 * @param array[] $schedules Schedule array items.
+	 */
+	$schedules = apply_filters( 'hm_post_repeat_schedules', array(
+		'daily'   => array( 'interval' => '1 day',   'display' => __( 'Daily',   'hm-post-repeat' ) ),
+		'weekly'  => array( 'interval' => '1 week',  'display' => __( 'Weekly',  'hm-post-repeat' ) ),
+		'monthly' => array( 'interval' => '1 month', 'display' => __( 'Monthly', 'hm-post-repeat' ) ),
+	) );
+
+	foreach ( $schedules as $slug => &$schedule ) {
+		$schedule['slug'] = $slug;
+	}
+
+	return $schedules;
+
+}
+
+/**
+ * Get the repeating schedule of the given post_id.
+ *
+ * @param int $post_id The id of the post you want to check.
+ * @return array|null The schedule to repeat by, or null if invalid.
+ */
+function get_repeating_schedule( $post_id ) {
+
+	if ( ! is_repeating_post( $post_id ) ) {
+		return null;
+	}
+
+	if ( $repeating_schedule = get_post_meta( $post_id, 'hm-post-repeat', true ) ) {
+		$schedules = repeating_schedules();
+		if ( array_key_exists( $repeating_schedule, $schedules ) ) {
+			return $schedules[ $repeating_schedule ];
+		}
+	}
+
+	return null;
+
+}
+
+/**
  * Check whether a given post_id is a repeating post.
  *
  * A repeating post is defined as the original post that was set to repeat.

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -144,7 +144,7 @@ function save_post_repeating_status() {
 	}
 
 	else {
-		update_post_meta( get_the_id(), 'hm-post-repeat', true );
+		update_post_meta( get_the_id(), 'hm-post-repeat', $_POST['hm-post-repeat'] );
 	}
 
 }

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -119,6 +119,10 @@ function publish_box_ui() {
 function post_states( $post_states ) {
 
 	if ( is_repeating_post( get_the_id() ) ) {
+
+		// Fix the saved schedule post meta when viewing the posts list
+		fix_repeating_schedule( get_the_id() );
+
 		// If the schedule has been removed since publishing, let the user know.
 		if ( get_repeating_schedule( get_the_id() ) ) {
 			$post_states['hm-post-repeat'] = __( 'Repeating', 'hm-post-repeat' );
@@ -161,6 +165,9 @@ function create_next_post( $post_id, $post ) {
 
 		// From here on we need the original post_id
 		$post_id = $post->post_parent;
+
+		// Fix the saved schedule post meta when publishing the next repeat post
+		fix_repeating_schedule( $post_id );
 	}
 
 	// Or the original
@@ -314,6 +321,22 @@ function get_repeating_schedule( $post_id ) {
 		if ( array_key_exists( $repeating_schedule, $schedules ) ) {
 			return $schedules[ $repeating_schedule ];
 		}
+	}
+
+}
+
+/**
+ * Fix the repeating schedule of the given post_id.
+ *
+ * This is to check existing repeating posts and correctly set the repeatable post meta.
+ * If the default "1" value is found, update it to the standard "weekly".
+ *
+ * @param int $post_id The id of the post you want to check.
+ */
+function fix_repeating_schedule( $post_id ) {
+
+	if ( $post_id && '1' === get_post_meta( $post_id, 'hm-post-repeat', true ) ) {
+		update_post_meta( $post_id, 'hm-post-repeat', 'weekly' );
 	}
 
 }


### PR DESCRIPTION
This change adds a custom list of repeating schedules to the drop down as discussed in #1.

The list of schedules can be extended via a filter, like so:
```php
add_filter( 'hm_post_repeat_schedules', function( $schedules ) {
	$schedules['twicemonthly'] = array( 'interval' => '2 weeks', 'display' => __( 'Twice Monthly', 'hm-post-repeat' ) );
	return $schedules;
} );
```

If a previously published schedule gets removed at some point, the post stops repeating and the user can easily find the posts affected:
![invalid-repeating-schedule](https://cloud.githubusercontent.com/assets/9423417/10258825/1c5828e2-6962-11e5-87d7-4cb1fecbd9fa.png)