### PR TITLE
Add extra tests for schedules

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,3 +1,79 @@
+filter:
+    excluded_paths: [ 'tests/*' ]
+
+tools:
+    php_code_sniffer:
+        config: { standard: WordPress }
+
+    php_changetracking:
+        enabled: true
+        bug_patterns:
+            - '\bfix(?:es|ed)?\b'
+        feature_patterns:
+            - '\badd(?:s|ed)?\b'
+            - '\bimplement(?:s|ed)?\b'
+
+    js_hint: true
+
+    php_mess_detector:
+        config:
+            naming_rules: { boolean_method_name: true }
+            controversial_rules: { superglobals: false }
+
+    sensiolabs_security_checker: true
+
+    php_loc: true
+
+    php_hhvm:
+        enabled: true
+        command: hhvm
+        extensions:
+            - php
+
+    php_analyzer:
+        enabled: true
+        extensions:
+              - php
+        config:
+            parameter_reference_check: { enabled: false }
+            checkstyle: { enabled: false }
+            unreachable_code: { enabled: true }
+            check_access_control: { enabled: false }
+            typo_checks: { enabled: true }
+            check_variables: { enabled: true }
+            check_calls: { enabled: true, too_many_arguments: true, missing_argument: true, argument_type_checks: lenient }
+            suspicious_code: { enabled: true, non_existent_class_in_instanceof_check: true, non_existent_class_in_catch_clause: true, non_commented_switch_fallthrough: true, non_commented_empty_catch_block: true, precedence_in_condition_assignment: true, overriding_parameter: false, overriding_closure_use: false, parameter_closure_use_conflict: false, parameter_multiple_times: false, assignment_of_null_return: false, overriding_private_members: false, use_statement_alias_conflict: false }
+            dead_assignments: { enabled: true }
+            verify_php_doc_comments: { enabled: true, parameters: true, return: true, suggest_more_specific_types: true, ask_for_return_if_not_inferrable: true, ask_for_param_type_annotation: true }
+            loops_must_use_braces: { enabled: false }
+            check_usage_context: { enabled: true, foreach: { value_as_reference: true, traversable: true } }
+            simplify_boolean_return: { enabled: true }
+            phpunit_checks: { enabled: false }
+            reflection_checks: { enabled: false }
+            precedence_checks: { enabled: true, assignment_in_condition: true, comparison_of_bit_result: true }
+            basic_semantic_checks: { enabled: true }
+            unused_code: { enabled: true }
+            deprecation_checks: { enabled: true }
+            useless_function_calls: { enabled: true }
+            metrics_lack_of_cohesion_methods: { enabled: true }
+            metrics_coupling: { enabled: true, stable_code: { namespace_prefixes: {  }, classes: {  } } }
+            doctrine_parameter_binding: { enabled: false }
+            doctrine_entity_manager_injection: { enabled: false }
+            symfony_request_injection: { enabled: false }
+            doc_comment_fixes: { enabled: false }
+            reflection_fixes: { enabled: false }
+            use_statement_fixes: { enabled: true, remove_unused: true, preserve_multiple: false, preserve_blanklines: false, order_alphabetically: false }
+
+    # PHP Similarity Analyzer and Copy/paste Detector cannot be used at
+    # the same time right now. Make sure to either remove, or disable one.
+    php_cpd: false
+
+    php_pdepend: true
+
+    php_sim:
+            enabled: true
+            min_mass: 50
+
 checks:
     php:
         code_rating: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 			Designate a post as repeatable and it'll be copied and re-published on a weekly basis.
 		</td>
 		<td align="right" width="30%">
+		
+		<a href="https://codecov.io/github/humanmade/repeatable-posts?branch=master">
+			<img src="https://codecov.io/github/humanmade/repeatable-posts/coverage.svg?branch=master" alt="Coverage via Codecov" />
+		</a>
+		
+		<br />
+		<a href="https://scrutinizer-ci.com/g/humanmade/repeatable-posts">
+			<img src="https://scrutinizer-ci.com/g/humanmade/repeatable-posts/badges/quality-score.png?b=master" alt="Scrutinizer Code Quality Score" />
+		</a>
+
+		<br />
+		<a href="https://travis-ci.org/humanmade/repeatable-posts">
+			<img src="https://travis-ci.org/humanmade/repeatable-posts.svg?branch=master" alt="Build Status" />
+		</a>
+	
 		</td>
 	</tr>
 	<tr>

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -155,9 +155,16 @@ function save_post_repeating_status( $post_id = null, $post_repeat_setting = nul
 
 	if ( 'no' === $post_repeat_setting ) {
 		delete_post_meta( $post_id, 'hm-post-repeat' );
+		return;
 	}
 
-	else {
+	// Backwards compatibility.
+	if ( '1' === $post_repeat_setting ) {
+		$post_repeat_setting = 'weekly';
+	}
+
+	// Make sure we have a valid schedule.
+	if ( in_array( $post_repeat_setting, array_keys( get_repeating_schedules() ) ) ) {
 		update_post_meta( $post_id, 'hm-post-repeat', $post_repeat_setting );
 	}
 

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -159,16 +159,10 @@ function save_post_repeating_status( $post_id = null, $post_repeat_setting = nul
 
 	if ( 'no' === $post_repeat_setting ) {
 		delete_post_meta( $post_id, 'hm-post-repeat' );
-		return;
-	}
-
-	// Backwards compatibility.
-	if ( '1' === $post_repeat_setting ) {
-		$post_repeat_setting = 'weekly';
 	}
 
 	// Make sure we have a valid schedule.
-	if ( in_array( $post_repeat_setting, array_keys( get_repeating_schedules() ) ) ) {
+	elseif ( in_array( $post_repeat_setting, array_keys( get_repeating_schedules() ) ) ) {
 		update_post_meta( $post_id, 'hm-post-repeat', $post_repeat_setting );
 	}
 

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -114,7 +114,8 @@ function publish_box_ui() {
  *
  * By default post states are displayed on the Edit Post screen in bold after the post title.
  *
- * @param array $post_states The original array of post states.
+ * @param array   $post_states The original array of post states.
+ * @param WP_Post $post        The post object to get / return the states.
  * @return array The array of post states with ours added.
  */
 function post_states( $post_states, $post ) {
@@ -142,6 +143,9 @@ function post_states( $post_states, $post ) {
  * Save the repeating status to post meta.
  *
  * Hooked into `save_post`. When saving a post that has been set to repeat we save a post meta entry.
+ *
+ * @param int    $post_id             The ID of the post.
+ * @param string $post_repeat_setting Used to manually set the repeating schedule from tests.
  */
 function save_post_repeating_status( $post_id = null, $post_repeat_setting = null ) {
 
@@ -172,14 +176,14 @@ function save_post_repeating_status( $post_id = null, $post_repeat_setting = nul
 
 
 /**
-* Create the next repeat post when the last one is published.
+ * Create the next repeat post when the last one is published.
  *
  * When a repeat post (or the original) is published we copy and schedule a new post
  * to publish on the correct interval. That way the next repeat post is always ready to go.
  * This is hooked into publish_post so that the repeat post is only created when the original
  * is published.
  *
- * @param int     $post_id The ID of the post.
+ * @param int $post_id The ID of the post.
  */
 function create_next_repeat_post( $post_id ) {
 
@@ -337,7 +341,7 @@ function get_repeating_schedule( $post_id ) {
 	$schedules = get_repeating_schedules();
 
 	// Backwards compatibility with 0.3 when we only supported weekly
-	if ( $repeating_schedule === '1' ) {
+	if ( '1' === $repeating_schedule ) {
 		$repeating_schedule = 'weekly';
 	}
 

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -363,11 +363,37 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * This test assumes that the meta data was invalidly set directly in the database.
+	 */
+	function test_get_repeating_schedule_invalid_direct_db_entry() {
+
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, 'hm-post-repeat', 'some-day' );
+		$this->assertNull( get_repeating_schedule( $post_id ) );
+
+	}
+
 	function test_get_repeating_schedule_invalid() {
 
 		$_POST['hm-post-repeat'] = 'some-day';
 		$post_id = $this->factory->post->create();
 		$this->assertNull( get_repeating_schedule( $post_id ) );
+
+	}
+
+	/**
+	 * This test assumes that the meta data was correctly set directly in the database.
+	 */
+	function test_get_repeating_schedule_valid_direct_db_entry() {
+
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, 'hm-post-repeat', 'daily' );
+		$this->assertSame( array(
+			'interval' => '1 day',
+			'display'  => 'Daily',
+			'slug'     => 'daily',
+		), get_repeating_schedule( $post_id ) );
 
 	}
 
@@ -384,7 +410,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * This method assumes an existing old schedule in the post meta.
+	 * This method assumes an existing old schedule format in the post meta.
 	 */
 	function test_get_repeating_schedule_backwards_compatible_old() {
 
@@ -399,7 +425,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * This method already saves the correct schedule to the post meta.
+	 * This method already saves the correct schedule format to the post meta.
 	 */
 	function test_get_repeating_schedule_backwards_compatible() {
 

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -23,7 +23,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$this->assertFalse( is_repeating_post( $post_id ) );
 
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 		$this->assertTrue( is_repeating_post( $post_id ) );
 
 	}
@@ -33,7 +33,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 		$post_id = $this->factory->post->create();
 		$this->assertFalse( is_repeating_post( $post_id ) );
 
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 		$this->assertTrue( is_repeating_post( $post_id ) );
 
 		save_post_repeating_status( $post_id );
@@ -60,7 +60,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 		$this->assertFalse( is_repeating_post( $post_id ) );
 
 		$_POST['ID'] = $post_id;
-		$_POST['hm-post-repeat'] = '1';
+		$_POST['hm-post-repeat'] = 'weekly';
 		$this->assertTrue( is_repeating_post( $post_id ) );
 
 	}
@@ -80,7 +80,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 		$this->assertFalse( is_repeat_post( $post_id ) );
 		$this->assertEquals( $parent_post_id, get_post( $post_id )->post_parent );
 
-		save_post_repeating_status( $parent_post_id, '1' );
+		save_post_repeating_status( $parent_post_id, 'weekly' );
 
 		$this->assertTrue( is_repeat_post( $post_id ) );
 
@@ -92,7 +92,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 		$parent_post_id = $this->factory->post->create();
 		$post_id = $this->factory->post->create( array( 'post_parent' => $parent_post_id ) );
-		save_post_repeating_status( $parent_post_id, '1' );
+		save_post_repeating_status( $parent_post_id, 'weekly' );
 
 		// Hack to allow us access to $post_states so we can test it
 		add_filter( 'display_post_states', function( $states, $post ) {
@@ -123,7 +123,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 		$parent_post_id = $this->factory->post->create();
 		$post_id = $this->factory->post->create( array( 'post_parent' => $parent_post_id ) );
-		save_post_repeating_status( $parent_post_id, '1' );
+		save_post_repeating_status( $parent_post_id, 'weekly' );
 
 		$this->assertEquals( $parent_post_id, get_repeating_post( $parent_post_id ) );
 		$this->assertEquals( $parent_post_id, get_repeating_post( $post_id ) );
@@ -141,7 +141,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	function test_create_repeat_post_from_published_repeating_post() {
 
 		$post_id = $this->factory->post->create();
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$this->assertCount( 0, get_posts( array( 'post_status' => 'future' ) ) );
 
@@ -157,7 +157,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	function test_create_repeat_post_from_unpublished_repeating_post() {
 
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$this->assertCount( 0, get_posts( array( 'post_status' => 'future' ) ) );
 
@@ -182,7 +182,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	function test_create_repeat_post_from_repeating_post_publish_action() {
 
 		$post_id = $this->factory->post->create( array( 'post_status' => 'draft' ) );
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$this->assertCount( 0, get_posts( array( 'post_status' => 'future' ) ) );
 
@@ -194,7 +194,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	function test_create_repeat_unsupported_repeating_post_type() {
 
 		$post_id = $this->factory->post->create( array( 'post_type' => 'middle-out-encryption' ) );
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$this->assertFalse( create_next_repeat_post( $post_id ) );
 
@@ -203,7 +203,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	function test_create_repeat_post_copies_meta() {
 
 		$post_id = $this->factory->post->create();
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$meta = array( 'NonEmptyString' => 'Test', 'Int' => 134, 'EmptyString' => '', 'bool' => true, 'object' => get_post( $post_id ), 'array' => get_post( $post_id, ARRAY_A ) );
 
@@ -238,7 +238,7 @@ class PostRepeatTests extends \WP_UnitTestCase {
 		$this->assertTrue( has_category( $cat1, $post_id ) );
 		$this->assertTrue( has_category( $cat2, $post_id ) );
 
-		save_post_repeating_status( $post_id, '1' );
+		save_post_repeating_status( $post_id, 'weekly' );
 
 		$repeat_post_id = create_next_repeat_post( $post_id );
 
@@ -416,21 +416,6 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 		$post_id = $this->factory->post->create();
 		add_post_meta( $post_id, 'hm-post-repeat', '1' );
-		$this->assertSame( array(
-			'interval' => '1 week',
-			'display'  => 'Weekly',
-			'slug'     => 'weekly',
-		), get_repeating_schedule( $post_id ) );
-
-	}
-
-	/**
-	 * This method already saves the correct schedule format to the post meta.
-	 */
-	function test_get_repeating_schedule_backwards_compatible() {
-
-		$_POST['hm-post-repeat'] = '1';
-		$post_id = $this->factory->post->create();
 		$this->assertSame( array(
 			'interval' => '1 week',
 			'display'  => 'Weekly',

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -363,4 +363,36 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 	}
 
+	function test_get_repeating_schedule_invalid() {
+
+		$_POST['hm-post-repeat'] = 'some-day';
+		$post_id = $this->factory->post->create();
+		$this->assertNull( get_repeating_schedule( $post_id ) );
+
+	}
+
+	function test_get_repeating_schedule_valid() {
+
+		$_POST['hm-post-repeat'] = 'daily';
+		$post_id = $this->factory->post->create();
+		$this->assertSame( array(
+			'interval' => '1 day',
+			'display'  => 'Daily',
+			'slug'     => 'daily',
+		), get_repeating_schedule( $post_id ) );
+
+	}
+
+	function test_get_repeating_schedule_backwards_compatible() {
+
+		$_POST['hm-post-repeat'] = '1';
+		$post_id = $this->factory->post->create();
+		$this->assertSame( array(
+			'interval' => '1 week',
+			'display'  => 'Weekly',
+			'slug'     => 'weekly',
+		), get_repeating_schedule( $post_id ) );
+
+	}
+
 }

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -264,4 +264,103 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 	}
 
+	function test_repeating_post_interval_invalid() {
+
+		$_POST['hm-post-repeat'] = 'some-day';
+		$post = $this->factory->post->create_and_get();
+		$this->assertFalse( is_repeating_post( $post->ID ) );
+
+		$future_posts = get_posts( array( 'post_status' => 'future' ) );
+		$this->assertCount( 0, $future_posts );
+
+	}
+
+	function test_add_custom_repeating_schedule() {
+
+		add_filter( 'hm_post_repeat_schedules', function( $schedules ) {
+
+			$schedules['yearly'] = array( 'interval' => '1 year', 'display' => 'Yearly' );
+			return $schedules;
+
+		} );
+
+		$this->assertTrue( key_exists( 'yearly', get_repeating_schedules() ) );
+
+	}
+
+	function test_repeating_post_interval_custom() {
+
+		add_filter( 'hm_post_repeat_schedules', function( $schedules ) {
+
+			$schedules['3-days'] = array( 'interval' => '3 days', 'display' => 'Every 3 days' );
+			return $schedules;
+
+		} );
+
+		$_POST['hm-post-repeat'] = '3-days';
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( is_repeating_post( $post->ID ) );
+
+		$future_posts = get_posts( array( 'post_status' => 'future' ) );
+		$this->assertCount( 1, $future_posts );
+
+		$repeat_post = reset( $future_posts );
+		$this->assertTrue( is_repeat_post( $repeat_post->ID ) );
+
+		$next_post_date = date( 'Y-m-d H:i:s', strtotime( $post->post_date . ' + 3 days' ) );
+		$this->assertSame( $repeat_post->post_date, $next_post_date );
+
+	}
+
+	function test_repeating_post_interval_daily() {
+
+		$_POST['hm-post-repeat'] = 'daily';
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( is_repeating_post( $post->ID ) );
+
+		$future_posts = get_posts( array( 'post_status' => 'future' ) );
+		$this->assertCount( 1, $future_posts );
+
+		$repeat_post = reset( $future_posts );
+		$this->assertTrue( is_repeat_post( $repeat_post->ID ) );
+
+		$next_post_date = date( 'Y-m-d H:i:s', strtotime( $post->post_date . ' + 1 day' ) );
+		$this->assertSame( $repeat_post->post_date, $next_post_date );
+
+	}
+
+	function test_repeating_post_interval_weekly() {
+
+		$_POST['hm-post-repeat'] = 'weekly';
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( is_repeating_post( $post->ID ) );
+
+		$future_posts = get_posts( array( 'post_status' => 'future' ) );
+		$this->assertCount( 1, $future_posts );
+
+		$repeat_post = reset( $future_posts );
+		$this->assertTrue( is_repeat_post( $repeat_post->ID ) );
+
+		$next_post_date = date( 'Y-m-d H:i:s', strtotime( $post->post_date . ' + 1 week' ) );
+		$this->assertSame( $repeat_post->post_date, $next_post_date );
+
+	}
+
+	function test_repeating_post_interval_monthly() {
+
+		$_POST['hm-post-repeat'] = 'monthly';
+		$post = $this->factory->post->create_and_get();
+		$this->assertTrue( is_repeating_post( $post->ID ) );
+
+		$future_posts = get_posts( array( 'post_status' => 'future' ) );
+		$this->assertCount( 1, $future_posts );
+
+		$repeat_post = reset( $future_posts );
+		$this->assertTrue( is_repeat_post( $repeat_post->ID ) );
+
+		$next_post_date = date( 'Y-m-d H:i:s', strtotime( $post->post_date . ' + 1 month' ) );
+		$this->assertSame( $repeat_post->post_date, $next_post_date );
+
+	}
+
 }

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -383,6 +383,24 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * This method assumes an existing old schedule in the post meta.
+	 */
+	function test_get_repeating_schedule_backwards_compatible_old() {
+
+		$post_id = $this->factory->post->create();
+		add_post_meta( $post_id, 'hm-post-repeat', '1' );
+		$this->assertSame( array(
+			'interval' => '1 week',
+			'display'  => 'Weekly',
+			'slug'     => 'weekly',
+		), get_repeating_schedule( $post_id ) );
+
+	}
+
+	/**
+	 * This method already saves the correct schedule to the post meta.
+	 */
 	function test_get_repeating_schedule_backwards_compatible() {
 
 		$_POST['hm-post-repeat'] = '1';


### PR DESCRIPTION
Add an extra statement to ensure backwards compatibility.
Ensure that the entered schedule is valid. This is mainly to prevent any errors by directly modifying the HTML values of the schedule dropdown.