### PR TITLE
Add filter to edit repeat post before it's saved

### DIFF
--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -40,7 +40,6 @@ add_action( 'save_post', __NAMESPACE__ . '\save_post_repeating_status', 10 );
 add_action( 'save_post', __NAMESPACE__ . '\create_next_repeat_post', 11 );
 add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_scripts' );
 add_filter( 'display_post_states', __NAMESPACE__ . '\post_states', 10, 2 );
-add_filter( 'hm_post_repeat_scheduled_post', __NAMESPACE__ . '\insert_date', 10, 2 );
 
 /**
  * Enqueue the scripts and styles that are needed by this plugin.
@@ -240,13 +239,13 @@ function create_next_repeat_post( $post_id ) {
 	}
 
 	/**
-	 * You can use this filter to modify the scheduled post before it gets stored
+	 * Use this filter to modify the scheduled post before it gets stored.
 	 *
-	 * @param array $next_post     The post data about to be saved
-	 * @param
-	 * @param array $original_post The original repeating post
+	 * @param array $next_post          The post data about to be saved.
+	 * @param array $repeating_schedule Repeating schedule info.
+	 * @param array $original_post      The original repeating post.
 	 */
-	$next_post = apply_filters( 'hm_post_repeat_scheduled_post', $next_post, $repeating_schedule, $original_post );
+	$next_post = apply_filters( 'hm_post_repeat_edit_repeat_post', $next_post, $repeating_schedule, $original_post );
 
 	// All checks done, get that post scheduled!
 	$next_post_id = wp_insert_post( wp_slash( $next_post ), true );
@@ -440,31 +439,4 @@ function get_repeating_post( $post_id ) {
 
 	return $original_post_id;
 
-}
-
-/**
- * Add support for a placeholder [date] in the title, this will be replaced
- * when the post is scheduled.
- *
- * @param array $next_post The scheduled post data array
- * @param array $schedule  The schedule array
- * @return array
- */
-function insert_date( $next_post, $schedule ) {
-
-	switch( $schedule['slug'] ) {
-		case 'weekly':
-			$format = '\W\e\e\k W Y';
-			break;
-		case 'monthly':
-			$format = 'F Y';
-			break;
-		default:
-			$format = get_option( 'date_format', 'Y-m-d' );
-	}
-
-	// Expand the placeholder
-	$next_post['post_title'] = str_replace( '[date]', date( $format, strtotime( $next_post['date'] ) ), $next_post['title'] );
-
-	return $next_post;
 }

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -424,4 +424,20 @@ class PostRepeatTests extends \WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Tests that the built in placeholder is properly expanded
+	 */
+	function test_repeat_post_replaces_placeholder() {
+
+		$_POST['hm-post-repeat'] = 'weekly';
+		$this->factory->post->create( array(
+			'post_title' => 'Scheduled post [date]',
+			'post_date'  => '2017-02-13 12:00:00',
+		) );
+
+		$repeat_posts = get_posts( array( 'post_status' => 'future' ) );
+
+		$this->assertSame( $repeat_posts[0]->post_title, 'Scheduled post Week 7 2017' );
+	}
+
 }

--- a/tests/test-repeat-posts.php
+++ b/tests/test-repeat-posts.php
@@ -425,19 +425,38 @@ class PostRepeatTests extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the built in placeholder is properly expanded
+	 * Tests that a repeat post is modified via filter before being saved/scheduled.
+	 * Only repeat posts with a specific schedule are modified.
 	 */
-	function test_repeat_post_replaces_placeholder() {
+	function test_edit_repeat_post_before_scheduling() {
 
+		// Edit repeat post title if it's on weekly schedule.
+		add_filter( 'hm_post_repeat_edit_repeat_post', function( $next_post, $repeating_schedule, $original_post ) {
+
+			if ( $repeating_schedule['slug'] === 'weekly' ) {
+				$next_post['post_title'] = 'Repeat Post Week 1, 2018';
+			}
+
+			return $next_post;
+		}, 10, 3 );
+
+		// Create main repeating post and schedule to repeat it weekly.
 		$_POST['hm-post-repeat'] = 'weekly';
-		$this->factory->post->create( array(
-			'post_title' => 'Scheduled post [date]',
-			'post_date'  => '2017-02-13 12:00:00',
+		$post_id = $this->factory->post->create( array(
+			'post_title'  => 'Repeating Post',
+			'post_status' => 'publish',
 		) );
 
+		// Check repeating post is there with its original title.
+		$this->assertTrue( is_repeating_post( $post_id ) );
+		$this->assertSame( get_the_title( $post_id ) , 'Repeating Post' );
+
+		// Check repeat post is scheduled with a new title.
 		$repeat_posts = get_posts( array( 'post_status' => 'future' ) );
 
-		$this->assertSame( $repeat_posts[0]->post_title, 'Scheduled post Week 7 2017' );
+		$this->assertNotEmpty( $repeat_posts );
+		$this->assertTrue( is_repeat_post( $repeat_posts[0]->ID ) );
+		$this->assertSame( $repeat_posts[0]->post_title, 'Repeat Post Week 1, 2018' );
 	}
 
 }


### PR DESCRIPTION
Introduces a method for adding placeholder content to be expanded. This code is kind of a suggestion at the moment, the may be a better more general approach where you can register a placeholder and callback like a shortcode instead. Filter is a good deal more flexible however.

Should we add any other built-ins?