### PR TITLE
Add row link to show all repeat posts

### DIFF
--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -489,8 +489,18 @@ function admin_table_views_links( $views ) {
 			number_format_i18n( $repeat_type_query->post_count )
 		);
 
-		// Add current class to the link to highlight it when it's selected.
-		$class_html = ( get_repeat_type_url_param() === $repeat_type ) ? ' class="current"' : '';
+		/**
+		 * Add current class to the view link to highlight it when it's selected.
+		 * NB: do not highlight the view link when displaying subsection of results
+		 * (i.e. Repeat posts for a specific Repeating post).
+		 */
+		$class_html = '';
+		if (
+			get_repeat_type_url_param() === $repeat_type &&
+			! isset( $_GET['post_parent'] )
+		) {
+			$class_html = ' class="current"';
+		}
 
 		$link_html = sprintf(
 			'<a href="%s"%s>%s</a>',

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -656,12 +656,37 @@ function admin_table_row_actions_view_repeat_posts( $actions, $post ) {
 		$actions['view_repeat'] = sprintf(
 			'<a href="%s" aria-label="%s">%s</a>',
 			esc_url( add_query_arg( $url_args, 'edit.php' ) ),
-			esc_attr( sprintf( __( 'View %d repeat posts', 'hm-post-repeat' ), $repeat_posts_count ) ),
-			esc_html( sprintf( __( '%d repeat posts', 'hm-post-repeat' ), $repeat_posts_count ) )
+			esc_attr( sprintf(
+				_n(
+					'View %d repeat post',
+					'View %d repeat posts',
+					$repeat_posts_count,
+					'hm-post-repeat'
+				),
+				number_format_i18n( $repeat_posts_count )
+			) ),
+			esc_html( sprintf(
+				_n(
+					'%d repeat post',
+					'%d repeat posts',
+					$repeat_posts_count,
+					'hm-post-repeat'
+				),
+				number_format_i18n( $repeat_posts_count )
+			) )
 		);
 	} else {
+
 		// 0 Repeat post - display text, not a link.
-		$actions['view_repeat'] = esc_html( sprintf( __( '%d repeat posts', 'hm-post-repeat' ), $repeat_posts_count ) );
+		$actions['view_repeat'] = esc_html( sprintf(
+			_n(
+				'%d repeat post',
+				'%d repeat posts',
+				$repeat_posts_count,
+				'hm-post-repeat'
+			),
+			number_format_i18n( $repeat_posts_count )
+		) );
 	}
 
 	return $actions;

--- a/hm-post-repeat.php
+++ b/hm-post-repeat.php
@@ -372,17 +372,21 @@ function get_repeating_schedule( $post_id ) {
  *
  * A repeating post is defined as the original post that was set to repeat.
  *
- * @param int $post_id The id of the post you want to check.
+ * @param int $post_id The ID of the post you want to check.
+ *
  * @return bool Whether the passed post_id is a repeating post or not.
  */
 function is_repeating_post( $post_id ) {
 
-	// We check $_POST data so that this function works inside a `save_post` hook when the post_meta hasn't yet been saved
+	// We check $_POST data so that this function works inside a `save_post` hook when the post_meta hasn't yet been saved.
 	if ( isset( $_POST['hm-post-repeat'] ) && isset( $_POST['ID'] ) && $_POST['ID'] === $post_id ) {
 		return true;
 	}
 
-	if ( get_post_meta( $post_id, 'hm-post-repeat', true ) ) {
+	// For saved posts - Repeating post has meta key and does NOT have a parent.
+	$post_parent = get_post_field( 'post_parent', $post_id );
+
+	if ( ! $post_parent && get_post_meta( $post_id, 'hm-post-repeat', true ) ) {
 		return true;
 	}
 
@@ -395,11 +399,13 @@ function is_repeating_post( $post_id ) {
  *
  * A repeat post is defined as any post which is a repeat of the original repeating post.
  *
- * @param int $post_id The id of the post you want to check.
+ * @param int $post_id The ID of the post you want to check.
+ *
  * @return bool Whether the passed post_id is a repeat post or not.
  */
 function is_repeat_post( $post_id ) {
 
+	// Repeat post has meta key and has a parent.
 	$post_parent = get_post_field( 'post_parent', $post_id );
 
 	if ( $post_parent && get_post_meta( $post_parent, 'hm-post-repeat', true ) ) {


### PR DESCRIPTION
Add a row link to each Repeating post with the count of its Repeat posts and ability to view only them.

Relates to #11 

<img width="865" alt="screenshot 2018-01-10 12 09 46" src="https://user-images.githubusercontent.com/2185972/34772292-7297c54c-f5ff-11e7-8b40-040fdc84da5e.png">
<img width="849" alt="screenshot 2018-01-10 12 10 07" src="https://user-images.githubusercontent.com/2185972/34772293-72bb235c-f5ff-11e7-8c57-66d08eb43158.png">

**Questions:**

1. Shall we add a column instead of row link - it might be easier to see this information?
2. A better way to store/count the number of `repeat` posts [here](https://github.com/humanmade/repeatable-posts/compare/add-row-link-to-show-all-repeat-posts?expand=1#diff-eedfb6e9d8d52eb8169e5eef4b936121R652) - otherwise it's gonna be an expensive thing to run.